### PR TITLE
[codex] Use writer-consistent reads after MySQL writes

### DIFF
--- a/lib/Strategies/QueryStrategy.php
+++ b/lib/Strategies/QueryStrategy.php
@@ -12,10 +12,20 @@ use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
 use PHPNomad\Datastore\Exceptions\RecordNotFoundException;
 use PHPNomad\MySql\Integration\Interfaces\DatabaseStrategy;
 use PHPNomad\Utils\Helpers\Arr;
-use PHPNomad\Utils\Helpers\Str;
+use Throwable;
 
 class QueryStrategy implements CoreQueryStrategy
 {
+    /**
+     * Tracks whether this strategy has written during the current request.
+     *
+     * After a write, managed hosts with read replicas may route normal reads to a
+     * stale replica. This flag lets only post-write reads use the writer-consistent
+     * path, so normal reads stay cheap while read-after-write hydration can see
+     * the row that was just inserted or changed.
+     */
+    protected bool $hasWritten = false;
+
     public function __construct(
         protected DatabaseStrategy $db,
         protected TableSchemaService $tableSchemaService,
@@ -26,6 +36,51 @@ class QueryStrategy implements CoreQueryStrategy
 
     /** @inheritDoc */
     public function query(QueryBuilder $builder): array
+    {
+        if ($this->hasWritten) {
+            return $this->queryAfterWrite($builder);
+        }
+
+        return $this->queryNormally($builder);
+    }
+
+    /**
+     * Executes a read through a path that can see preceding writes.
+     *
+     * @param QueryBuilder $builder
+     * @return array
+     * @throws DatastoreErrorException
+     * @throws RecordNotFoundException
+     */
+    protected function queryAfterWrite(QueryBuilder $builder): array
+    {
+        $this->db->query('START TRANSACTION');
+
+        try {
+            $result = $this->queryNormally($builder);
+            $this->db->query('COMMIT');
+
+            return $result;
+        } catch (Throwable $e) {
+            try {
+                $this->db->query('ROLLBACK');
+            } catch (Throwable $rollbackException) {
+                // Preserve the original read failure.
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Executes a normal read query using the configured database strategy.
+     *
+     * @param QueryBuilder $builder
+     * @return array
+     * @throws DatastoreErrorException
+     * @throws RecordNotFoundException
+     */
+    protected function queryNormally(QueryBuilder $builder): array
     {
         try {
             $result = $this->db->query($builder->build());
@@ -60,8 +115,24 @@ class QueryStrategy implements CoreQueryStrategy
             ...Arr::values($data)
         );
 
-        $this->db->query($query);
-        return $this->resolveInsertIdentity($table, $data);
+        $this->db->query('START TRANSACTION');
+
+        try {
+            $this->db->query($query);
+            $identity = $this->resolveInsertIdentity($table, $data);
+            $this->db->query('COMMIT');
+            $this->hasWritten = true;
+
+            return $identity;
+        } catch (Throwable $e) {
+            try {
+                $this->db->query('ROLLBACK');
+            } catch (Throwable $rollbackException) {
+                // Preserve the original insert failure.
+            }
+
+            throw $e;
+        }
     }
 
     /**
@@ -119,6 +190,7 @@ class QueryStrategy implements CoreQueryStrategy
         );
 
         $this->db->query($query);
+        $this->hasWritten = true;
     }
 
     /** @inheritDoc */
@@ -158,6 +230,8 @@ class QueryStrategy implements CoreQueryStrategy
         if ($result === 0) {
             throw new RecordNotFoundException('The update failed because no record exists with the specified IDs.');
         }
+
+        $this->hasWritten = true;
     }
 
 

--- a/tests/Unit/Strategies/QueryStrategyTest.php
+++ b/tests/Unit/Strategies/QueryStrategyTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace PHPNomad\MySql\Integration\Tests\Unit\Strategies;
+
+use PHPNomad\Database\Factories\Column;
+use PHPNomad\Database\Interfaces\ClauseBuilder;
+use PHPNomad\Database\Interfaces\QueryBuilder;
+use PHPNomad\Database\Interfaces\Table;
+use PHPNomad\Database\Services\TableSchemaService;
+use PHPNomad\MySql\Integration\Interfaces\DatabaseStrategy;
+use PHPNomad\MySql\Integration\Strategies\QueryStrategy;
+use PHPUnit\Framework\TestCase;
+
+class QueryStrategyTest extends TestCase
+{
+    public function testInsertResolvesLastInsertIdInsideTransaction(): void
+    {
+        $db = new InsertTransactionDatabaseStrategyStub();
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->expects($this->once())
+            ->method('getPrimaryColumnsForTable')
+            ->willReturn([new Column('id', 'INT', null, 'AUTO_INCREMENT')]);
+
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn('test_records');
+
+        $strategy = new QueryStrategy(
+            $db,
+            $tableSchemaService,
+            $this->createMock(ClauseBuilder::class)
+        );
+
+        $identity = $strategy->insert($table, ['name' => 'Example']);
+
+        $this->assertSame(['id' => 123], $identity);
+        $this->assertSame([
+            'START TRANSACTION',
+            'INSERT INTO test_records (name) VALUES ("Example")',
+            'SELECT LAST_INSERT_ID()',
+            'COMMIT',
+        ], $db->queries);
+        $this->assertTrue($db->lastInsertIdQueriedInTransaction);
+    }
+
+    public function testQueryUsesTransactionBackedReadAfterInsert(): void
+    {
+        $db = new InsertTransactionDatabaseStrategyStub();
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->expects($this->once())
+            ->method('getPrimaryColumnsForTable')
+            ->willReturn([new Column('id', 'INT', null, 'AUTO_INCREMENT')]);
+
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn('test_records');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->expects($this->once())
+            ->method('build')
+            ->willReturn('SELECT * FROM test_records WHERE id = 123');
+
+        $strategy = new QueryStrategy(
+            $db,
+            $tableSchemaService,
+            $this->createMock(ClauseBuilder::class)
+        );
+
+        $strategy->insert($table, ['name' => 'Example']);
+
+        $this->assertSame([['id' => 123, 'name' => 'Example']], $strategy->query($queryBuilder));
+        $this->assertSame([
+            'START TRANSACTION',
+            'INSERT INTO test_records (name) VALUES ("Example")',
+            'SELECT LAST_INSERT_ID()',
+            'COMMIT',
+            'START TRANSACTION',
+            'SELECT * FROM test_records WHERE id = 123',
+            'COMMIT',
+        ], $db->queries);
+    }
+}
+
+class InsertTransactionDatabaseStrategyStub implements DatabaseStrategy
+{
+    public array $queries = [];
+    public bool $lastInsertIdQueriedInTransaction = false;
+    private bool $inTransaction = false;
+
+    public function parse(string $query, ...$args): string
+    {
+        return 'INSERT INTO test_records (name) VALUES ("Example")';
+    }
+
+    public function query(string $query)
+    {
+        $this->queries[] = $query;
+
+        if ($query === 'START TRANSACTION') {
+            $this->inTransaction = true;
+
+            return 1;
+        }
+
+        if ($query === 'COMMIT' || $query === 'ROLLBACK') {
+            $this->inTransaction = false;
+
+            return 1;
+        }
+
+        if ($query === 'SELECT LAST_INSERT_ID()') {
+            $this->lastInsertIdQueriedInTransaction = $this->inTransaction;
+
+            return [['LAST_INSERT_ID()' => 123]];
+        }
+
+        if (str_starts_with($query, 'SELECT *')) {
+            return $this->inTransaction ? [['id' => 123, 'name' => 'Example']] : [];
+        }
+
+        return 1;
+    }
+}


### PR DESCRIPTION
## What changed

This keeps the read-after-write consistency fix entirely inside the MySQL integration.

The behavior is dynamic:

- Normal reads still use the normal query path.
- `insert()` runs the insert and `SELECT LAST_INSERT_ID()` inside the same transaction.
- After `insert()`, `update()`, or `delete()`, the strategy marks that a write occurred.
- Subsequent reads through that strategy instance are wrapped in a short transaction so they use the writer-consistent path.

No datastore-layer interface was added. No public API changed.

## Why

PHPNomad's datastore create flow inserts a row, resolves its identity, and then reads the model back. On managed MySQL hosts with read/write splitting, a read immediately after a write can hit a stale reader.

This fix keeps normal reads cheap while ensuring reads that happen after a write can see the write.

## Production Evidence Behind This Fix

The triggering incident was observed on the WordPress integration, but the failure mode is MySQL-level: a write commits, then PHPNomad immediately reads the created row to hydrate the model.

Darren's live SmartWorkflowGuru database was pulled into a disposable test install with WP Migrate DB Pro on April 28, 2026. The failed WooCommerce/Stripe order showed:

- WooCommerce order `8870` completed at `2026-04-27 16:27:03` UTC.
- Siren conversions `19` and `20` were created at `2026-04-27 16:26:49` and `2026-04-27 16:26:57` UTC with `transactionId = NULL`.
- Siren transaction rows `29` and `30` existed with matching timestamps, proving the inserts committed.
- Transaction `30` also had a transaction detail row, but neither transaction had a `wc_order` mapping for order `8870`.
- Earlier live logs showed `RecordNotFoundException` during `IdentifiableDatabaseDatastoreHandler->create()` immediately after inserts.

That shape is exactly what happens when PHPNomad's insert succeeds but the immediate post-write read path cannot see the row. The MySQL integration has the same insert-then-read datastore contract, so it gets the same writer-consistent treatment.

## Cloudways Test Notes

A standard Cloudways test app was loaded with the live DB. It used plain local-socket MySQL, not the customer's Cloudways Autonomous topology:

- `$wpdb` class: `wpdb`
- `wp-content/db.php`: absent
- `DB_HOST`: local socket (`localhost:/run/mysqld/mysqld.sock`)

On that standard Cloudways app, the issue did not reproduce:

- 100 direct insert/select cycles outside a transaction: 0 failures.
- 100 direct insert/select cycles inside a transaction: 0 failures.
- 10 replays of the WooCommerce completed-order hook outside a transaction: all succeeded.
- 10 replays inside a transaction: all succeeded.

This confirms the generic Cloudways app is not equivalent to the customer's Autonomous database topology. The production DB artifact still supports the read-after-write consistency fix.

## Impact

This should prevent a successful insert from being followed by a stale read that makes PHPNomad behave as if the inserted row does not exist.

The extra transaction work only happens on insert identity resolution and on reads after a write has occurred in the same query strategy instance.

## Validation

- `/home/alex/projects/phpnomad/db/vendor/bin/phpunit --testdox --bootstrap tests/bootstrap.php tests/Unit/Strategies/QueryStrategyTest.php`
- Result: 2 tests, 8 assertions passing

## Note

The full mysql-integration test suite is still blocked by pre-existing package bootstrap drift: there is no local `vendor/bin/phpunit`, and `tests/Unit/ValidateCITest.php` references the old `Phoenix\\Core\\Tests\\TestCase` namespace.