### PR TITLE
fix(clause-builder): drop predicate when field isn't on the active table

### DIFF
--- a/lib/Builders/MySqlClauseBuilder.php
+++ b/lib/Builders/MySqlClauseBuilder.php
@@ -125,9 +125,16 @@ class MySqlClauseBuilder implements ClauseBuilder
             return $this;
         }
 
-        $placeholder = $this->generatePlaceholder($field, $values, $operator);
-
         $fieldStr = $this->getFieldString($field);
+
+        // If the field isn't on the active table, drop the whole predicate.
+        // Otherwise we'd push `null` for the field but still emit the operator
+        // and placeholder, producing invalid SQL like `WHERE = 'value'`.
+        if ($fieldStr === null) {
+            return $this;
+        }
+
+        $placeholder = $this->generatePlaceholder($field, $values, $operator);
 
         if (!empty($this->clauses) && $logic && in_array(strtoupper($logic), ['AND', 'OR'])) {
             $this->clauses[] = strtoupper($logic);


### PR DESCRIPTION
## Summary

`addCondition()` calls `getFieldString()`, which returns `null` for any field not declared on the bound table — a legitimate filter to drop unknown fields silently. But the rest of `addCondition` still pushes the operator and placeholder onto the clauses array regardless, producing invalid SQL like \`WHERE = 'value'\` (or \`WHERE AND = 'value'\` when chained).

This skips the entire predicate when \`fieldStr\` is null, which matches the apparent intent of \`getFieldString\` returning null in the first place.

## Why this matters

Caught while porting the clause builder to \`phpnomad/sqlite-integration\`. Wrote a test asserting that unknown fields silently no-op the predicate; instead the test produced a SQL syntax error from the engine. The SQLite port carries the same fix.

## Test plan

- [ ] Existing test suite continues to pass
- [ ] A new test in this repo (parallel to the SQLite one) that calls \`->where('not_a_field', '=', 'x')\` and confirms the query is a no-op rather than producing invalid SQL

The fix is one branch — no behavior change for valid fields, only fixes the broken silent-filter path.