### PR TITLE
fix(query-builder): default alias for count('*') is no longer invalid SQL

### DIFF
--- a/lib/Builders/QueryBuilder.php
+++ b/lib/Builders/QueryBuilder.php
@@ -166,7 +166,12 @@ class QueryBuilder implements QueryBuilderInterface
     /** @inheritDoc */
     public function count(string $fieldToCount, ?string $alias = null)
     {
-        $alias = $alias ?: $fieldToCount . '_count';
+        // Default alias is "<field>_count", with a special case for `*` —
+        // `*_count` isn't a valid SQL identifier and produces a syntax error
+        // when the query is executed.
+        if ($alias === null) {
+            $alias = $fieldToCount === '*' ? 'count' : $fieldToCount . '_count';
+        }
 
         if($fieldToCount !== '*'){
             $fieldToCount = $this->prependField($fieldToCount);


### PR DESCRIPTION
## Summary

\`count('*')\` without an explicit alias produces \`as *_count\`, which isn't a valid SQL identifier:

\`\`\`
SELECT COUNT(*) as *_count FROM users AS u
                   ^^^^^^^^
                   syntax error near \"*\"
\`\`\`

This defaults to the bare identifier \`count\` when the field is \`*\`. Existing behavior for non-star fields (\`field_count\`, with the field name as prefix) is preserved.

## Why this matters

Caught while porting the QueryBuilder to \`phpnomad/sqlite-integration\`. A test that called \`->count('*')\` without an alias produced a query that the engine rejected. The SQLite port carries the same fix.

## Test plan

- [ ] Existing test suite continues to pass
- [ ] A new test in this repo: \`->count('*')->build()\` produces SQL whose alias parses cleanly (e.g. assert the emitted alias is \`count\`, not \`*_count\`)
- [ ] Existing usages that pass an explicit alias remain unchanged