### PR TITLE
PDO database strategy — maintained replacement for SafeMySQL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests export-ignore
+/.github export-ignore
+/phpunit.xml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,6 +14,18 @@ jobs:
         # own constraints. composer.json should declare an explicit PHP
         # floor matching this (separate cleanup).
         php: [ '8.2', '8.3' ]
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3308:3306
+        options: >-
+          --health-cmd="mysqladmin ping -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - uses: actions/checkout@v4
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require": {
         "phpnomad/db": "^2.0",
-        "phpnomad/loader": "^1.0 || ^2.0"
+        "phpnomad/loader": "^1.0 || ^2.0",
+        "ext-pdo": "*"
     },
     "require-dev": {
         "phpnomad/tests": "^0.1.0 || ^0.3.0"

--- a/lib/Connections/PdoConnection.php
+++ b/lib/Connections/PdoConnection.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PHPNomad\MySql\Integration\Connections;
+
+use PDO;
+
+/**
+ * Lazily-opened PDO connection for the PDO database strategies.
+ *
+ * Accepts the same configuration shape consumers passed to SafeMySQL
+ * (host / user / pass / db / port / charset), so migrating off the
+ * abandoned colshrapnel/safemysql backend is a binding swap. An existing
+ * PDO instance can also be wrapped directly via fromPdo() — useful for
+ * tests and for applications that manage their own connection.
+ */
+class PdoConnection
+{
+    protected ?PDO $pdo = null;
+
+    /** @var array<string, mixed> */
+    protected array $config;
+
+    /**
+     * @param array{host?: string, user?: string, pass?: string, db?: string, port?: int, charset?: string} $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    public static function fromPdo(PDO $pdo): static
+    {
+        $connection = new static();
+        $connection->pdo = $pdo;
+
+        return $connection;
+    }
+
+    public function pdo(): PDO
+    {
+        if ($this->pdo === null) {
+            $host = $this->config['host'] ?? 'localhost';
+            $port = (int) ($this->config['port'] ?? 3306);
+            $db = $this->config['db'] ?? '';
+            $charset = $this->config['charset'] ?? 'utf8mb4';
+
+            $this->pdo = new PDO(
+                "mysql:host={$host};port={$port};dbname={$db};charset={$charset}",
+                $this->config['user'] ?? 'root',
+                $this->config['pass'] ?? '',
+                [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]
+            );
+        }
+
+        return $this->pdo;
+    }
+}

--- a/lib/Connections/PdoConnection.php
+++ b/lib/Connections/PdoConnection.php
@@ -51,6 +51,12 @@ class PdoConnection
                 [
                     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    // Parity with the mysqli-based SafeMySQL backend this
+                    // strategy replaces: all column values arrive as strings.
+                    // Consumers were written against that typing; native
+                    // int/float fetches would silently change cache-key
+                    // hashing and strict comparisons downstream.
+                    PDO::ATTR_STRINGIFY_FETCHES => true,
                 ]
             );
         }

--- a/lib/Strategies/PdoAtomicOperationStrategy.php
+++ b/lib/Strategies/PdoAtomicOperationStrategy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PHPNomad\MySql\Integration\Strategies;
+
+use PHPNomad\Database\Interfaces\AtomicOperationStrategy;
+use PHPNomad\MySql\Integration\Connections\PdoConnection;
+
+class PdoAtomicOperationStrategy implements AtomicOperationStrategy
+{
+    public function __construct(protected PdoConnection $connection)
+    {
+    }
+
+    /** @inheritDoc */
+    public function atomic(callable $operation)
+    {
+        $pdo = $this->connection->pdo();
+        $pdo->beginTransaction();
+
+        try {
+            $result = $operation();
+            $pdo->commit();
+
+            return $result;
+        } catch (\Throwable $e) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/lib/Strategies/PdoDatabaseStrategy.php
+++ b/lib/Strategies/PdoDatabaseStrategy.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace PHPNomad\MySql\Integration\Strategies;
+
+use PDOException;
+use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+use PHPNomad\MySql\Integration\Connections\PdoConnection;
+use PHPNomad\MySql\Integration\Interfaces\DatabaseStrategy;
+
+/**
+ * PDO-backed DatabaseStrategy: the maintained replacement for the
+ * abandoned colshrapnel/safemysql backend (phpnomad/safemysql-integration#2).
+ *
+ * parse() implements the same placeholder language SafeMySQL defined —
+ * ?n identifier, ?s string, ?i integer, ?a IN-list, ?u SET clause,
+ * ?p raw fragment — including the argument preprocessing the SafeMySQL
+ * integration layered on top (lists of row arrays and associative arrays
+ * become raw VALUES tuples; scalars reaching ?a are wrapped), because the
+ * query builders depend on those behaviors. Value escaping is delegated
+ * to the driver via PDO::quote(), never hand-rolled.
+ */
+class PdoDatabaseStrategy implements DatabaseStrategy
+{
+    public function __construct(protected PdoConnection $connection)
+    {
+    }
+
+    /** @inheritDoc */
+    public function parse(string $query, ...$args): string
+    {
+        $parts = preg_split('/(\?[nsiaup])/', $query, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $result = '';
+        $index = 0;
+
+        foreach ($parts as $i => $part) {
+            if (($i % 2) === 0) {
+                $result .= $part;
+                continue;
+            }
+
+            $value = $args[$index] ?? null;
+            $index++;
+
+            // The SafeMySQL integration accepted richer argument shapes than
+            // the base placeholder language: a list of row arrays (bulk
+            // INSERT VALUES) or a single associative array arriving at ?a/?p
+            // becomes a raw, fully-escaped tuples fragment. Preserved here
+            // because the query builders depend on it. ?u is exempt — it
+            // legitimately consumes an associative array.
+            if (in_array($part, ['?a', '?p'], true) && is_array($value) && !empty($value)) {
+                if (is_array(reset($value))) {
+                    $result .= $this->convertRowTuples($value);
+                    continue;
+                }
+                if ($this->isAssociativeArray($value)) {
+                    $result .= $this->convertRowTuples([$value]);
+                    continue;
+                }
+            }
+
+            $result .= match ($part) {
+                '?n' => $this->escapeIdentifier((string) $value),
+                '?s' => $this->escapeString($value),
+                '?i' => $this->escapeInt($value),
+                '?a' => $this->createInList(is_array($value) ? $value : [$value]),
+                '?u' => $this->createSetClause((array) $value),
+                '?p' => (string) $value,
+            };
+        }
+
+        return $result;
+    }
+
+    /** @inheritDoc */
+    public function query(string $query)
+    {
+        try {
+            $statement = $this->connection->pdo()->query($query);
+
+            if ($statement->columnCount() > 0) {
+                return $statement->fetchAll();
+            }
+
+            return $statement->rowCount();
+        } catch (PDOException $e) {
+            // Keep the message stable: SQL and driver error detail must not
+            // reach clients. The chained exception carries it for loggers.
+            throw new DatastoreErrorException('Failed to execute query.', 500, $e);
+        }
+    }
+
+    protected function escapeIdentifier(string $name): string
+    {
+        return '`' . str_replace('`', '``', $name) . '`';
+    }
+
+    protected function escapeString(mixed $value): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        return $this->connection->pdo()->quote((string) $value);
+    }
+
+    protected function escapeInt(mixed $value): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        if (is_float($value)) {
+            return number_format($value, 0, '.', '');
+        }
+
+        return (string) (int) $value;
+    }
+
+    /**
+     * @param array<int, mixed> $values
+     */
+    protected function createInList(array $values): string
+    {
+        if (empty($values)) {
+            return 'NULL';
+        }
+
+        return implode(',', array_map(fn($value) => $this->escapeString($value), $values));
+    }
+
+    /**
+     * @param array<string, mixed> $pairs
+     */
+    protected function createSetClause(array $pairs): string
+    {
+        $sets = [];
+        foreach ($pairs as $column => $value) {
+            $sets[] = $this->escapeIdentifier((string) $column) . '=' . $this->escapeString($value);
+        }
+
+        return implode(', ', $sets);
+    }
+
+    protected function isAssociativeArray(array $arr): bool
+    {
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $tuples
+     */
+    protected function convertRowTuples(array $tuples): string
+    {
+        $rows = [];
+        foreach ($tuples as $tuple) {
+            $values = [];
+            foreach ($tuple as $value) {
+                if (is_null($value)) {
+                    $values[] = 'NULL';
+                } elseif (is_int($value) || is_float($value)) {
+                    $values[] = (string) $value;
+                } else {
+                    $values[] = $this->escapeString($value);
+                }
+            }
+            $rows[] = '(' . implode(', ', $values) . ')';
+        }
+
+        return implode(', ', $rows);
+    }
+}

--- a/tests/Unit/Strategies/PdoDatabaseStrategyTest.php
+++ b/tests/Unit/Strategies/PdoDatabaseStrategyTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace PHPNomad\MySql\Integration\Tests\Unit\Strategies;
+
+use PDO;
+use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+use PHPNomad\MySql\Integration\Connections\PdoConnection;
+use PHPNomad\MySql\Integration\Strategies\PdoDatabaseStrategy;
+use PHPNomad\MySql\Integration\Tests\TestCase;
+
+/**
+ * Pins the SafeMySQL-compatible placeholder language the query builders
+ * depend on (?n ?s ?i ?a ?u ?p plus the row-tuple argument preprocessing),
+ * now backed by PDO. Runs against a real MySQL when reachable
+ * (TEST_MYSQL_DSN/USER/PASS, defaulting to 127.0.0.1:3308) and skips
+ * otherwise.
+ */
+class PdoDatabaseStrategyTest extends TestCase
+{
+    private function makeStrategy(): PdoDatabaseStrategy
+    {
+        $dsn = getenv('TEST_MYSQL_DSN') ?: 'mysql:host=127.0.0.1;port=3308;charset=utf8mb4';
+        $user = getenv('TEST_MYSQL_USER') ?: 'root';
+        $pass = getenv('TEST_MYSQL_PASS') ?: 'root';
+
+        try {
+            $pdo = new PDO($dsn, $user, $pass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        } catch (\PDOException $e) {
+            $this->markTestSkipped('No MySQL server reachable for PDO strategy tests: ' . $e->getMessage());
+        }
+
+        $pdo->exec('CREATE DATABASE IF NOT EXISTS phpnomad_pdo_test');
+        $pdo->exec('USE phpnomad_pdo_test');
+
+        return new PdoDatabaseStrategy(PdoConnection::fromPdo($pdo));
+    }
+
+    /**
+     * @dataProvider placeholderProvider
+     */
+    public function testParse(string $query, array $args, string $expected): void
+    {
+        $this->assertSame($expected, $this->makeStrategy()->parse($query, ...$args));
+    }
+
+    public static function placeholderProvider(): array
+    {
+        return [
+            'identifier' => ["SELECT * FROM ?n", ['users'], "SELECT * FROM `users`"],
+            'identifier with embedded backtick' => ["SELECT ?n", ['we`ird'], "SELECT `we``ird`"],
+            'string' => ["WHERE name = ?s", ['Alex'], "WHERE name = 'Alex'"],
+            'string null' => ["SET ref = ?s", [null], "SET ref = NULL"],
+            'string escapes quotes' => ["WHERE name = ?s", ["O'Neil"], "WHERE name = 'O\\'Neil'"],
+            'integer' => ["LIMIT ?i", ['25'], "LIMIT 25"],
+            'integer null' => ["SET count = ?i", [null], "SET count = NULL"],
+            'integer truncates float' => ["LIMIT ?i", [3.9], "LIMIT 4"],
+            'in list' => ["WHERE id IN(?a)", [[1, 'two', null]], "WHERE id IN('1','two',NULL)"],
+            'in list from scalar wraps' => ["WHERE id IN(?a)", [7], "WHERE id IN('7')"],
+            'set clause' => ["SET ?u", [[]], "SET "],
+            'raw' => ["ORDER BY ?p", ['created DESC'], "ORDER BY created DESC"],
+            'list of rows becomes tuples' => [
+                "VALUES ?a",
+                [[['a' => 1, 'b' => 'x'], ['a' => 2, 'b' => null]]],
+                "VALUES (1, 'x'), (2, NULL)",
+            ],
+            'associative array becomes single tuple' => [
+                "VALUES ?a",
+                [['a' => 1, 'b' => 'x']],
+                "VALUES (1, 'x')",
+            ],
+            'multiple placeholders consume in order' => [
+                "SELECT ?n FROM ?n WHERE id = ?i AND name = ?s",
+                ['col', 'tbl', 5, 'x'],
+                "SELECT `col` FROM `tbl` WHERE id = 5 AND name = 'x'",
+            ],
+        ];
+    }
+
+    public function testParseSetClauseWithPairs(): void
+    {
+        $result = $this->makeStrategy()->parse("UPDATE t SET ?u", ['name' => 'Alex', 'age' => null]);
+
+        $this->assertSame("UPDATE t SET `name`='Alex', `age`=NULL", $result);
+    }
+
+    public function testQueryReturnsRowsForSelect(): void
+    {
+        $strategy = $this->makeStrategy();
+        $strategy->query('CREATE TEMPORARY TABLE t (id INTEGER, name TEXT)');
+        $strategy->query("INSERT INTO t VALUES (1, 'a'), (2, 'b')");
+
+        $rows = $strategy->query('SELECT * FROM t ORDER BY id');
+
+        $this->assertSame([['id' => 1, 'name' => 'a'], ['id' => 2, 'name' => 'b']], $rows);
+    }
+
+    public function testQueryReturnsAffectedRowCountForWrites(): void
+    {
+        $strategy = $this->makeStrategy();
+        $strategy->query('CREATE TEMPORARY TABLE t (id INTEGER)');
+        $strategy->query('INSERT INTO t VALUES (1), (2), (3)');
+
+        $affected = $strategy->query('DELETE FROM t WHERE id > 1');
+
+        $this->assertSame(2, $affected);
+    }
+
+    public function testQueryFailureThrowsStableMessage(): void
+    {
+        $this->expectException(DatastoreErrorException::class);
+        $this->expectExceptionMessage('Failed to execute query.');
+
+        $this->makeStrategy()->query('SELECT * FROM missing_table');
+    }
+}

--- a/tests/Unit/Strategies/PdoDatabaseStrategyTest.php
+++ b/tests/Unit/Strategies/PdoDatabaseStrategyTest.php
@@ -27,6 +27,7 @@ class PdoDatabaseStrategyTest extends TestCase
             $pdo = new PDO($dsn, $user, $pass, [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_STRINGIFY_FETCHES => true,
             ]);
         } catch (\PDOException $e) {
             $this->markTestSkipped('No MySQL server reachable for PDO strategy tests: ' . $e->getMessage());
@@ -94,7 +95,8 @@ class PdoDatabaseStrategyTest extends TestCase
 
         $rows = $strategy->query('SELECT * FROM t ORDER BY id');
 
-        $this->assertSame([['id' => 1, 'name' => 'a'], ['id' => 2, 'name' => 'b']], $rows);
+        // Stringified fetches pin parity with the mysqli-based backend.
+        $this->assertSame([['id' => '1', 'name' => 'a'], ['id' => '2', 'name' => 'b']], $rows);
     }
 
     public function testQueryReturnsAffectedRowCountForWrites(): void


### PR DESCRIPTION
Implements the replacement path from phpnomad/safemysql-integration#2: `PdoConnection` + `PdoDatabaseStrategy` + `PdoAtomicOperationStrategy` with the full SafeMySQL placeholder language (driver-delegated escaping), behavior-parity preprocessing, stable error messages, and real-MySQL tests (CI gains a mysql service). Consumers swap bindings and drop colshrapnel/safemysql entirely.